### PR TITLE
I learned some Martian today...(fixes)

### DIFF
--- a/content/advanced-features/index.md
+++ b/content/advanced-features/index.md
@@ -71,7 +71,7 @@ configure the job:
 |`env`|Specifies environment variables which are required to be set in this job mode.|
 
 `mrp` will execute the specified `cmd` with the specified `args` and pipe a job
-script to its standard input (see [Templates](#Templates) below for how the job
+script to its standard input (see [Templates](#templates) below for how the job
 script is generated).  If the command's standard output consists of a string
 with no newlines or whitespace, it is interpreted as a job ID and recorded with
 the job, to potentially be used later with the `queue_query` script.
@@ -115,7 +115,7 @@ the number of threads they parallize jobs over, for example `OMP_NUM_THREADS`
 for OpenMP.  The `thread_envs` key specifies a list of environment variables
 which should be set to be equal to the job thread reservation.  These are
 applied in cluster mode, and in local mode if the number of threads is
-constrained.  In local mode without a constraint on mrp's total thread count,
+constrained.  In local mode without a constraint on `mrp`'s total thread count,
 it is not used, as it's expected that the user is not sharing the machine with
 other users, so such a constraint on internal parallelism is just potentially
 idle CPU cycles.

--- a/content/inspecting-pipelines/index.md
+++ b/content/inspecting-pipelines/index.md
@@ -165,14 +165,14 @@ The URL is also written to the pipestance metadata file named `_uiport`.
 To access the UI, simply direct your browser to the specified URL.
 
 Alternatively, you may choose a specific port using the `--uiport` command-line option.
-By default, if a specific port is chosen the authentication token is only
+By default, if a specific port is chosen, the authentication token is only
 required for API calls which modify the pipestance state.  These default
-behaviors can call be altered with the `mrp` flags
+behaviors can be altered with the `mrp` flags
 `--disable-ui`, `--disable-auth`, `--require-auth`, and `--auth-key`.
 
-Normally, when a pipeline run completes, mrp terminates and the user interface
+Normally, when a pipeline run completes, `mrp` terminates and the user interface
 is no longer available.  If `mrp` was started with `--noexit` then it will stay
-up until mrp is killed (either with an operating system signal or with
+up until `mrp` is killed (either with an operating system signal or with
 `mrstat --stop`).
 
 ### Pipeline details

--- a/content/language-details/index.md
+++ b/content/language-details/index.md
@@ -6,9 +6,9 @@ type: post
 
 ## Tokens and Grammar
 
-The Martian language's tokens are defined by regular expressions in its [lexical scanner](https://github.com/martian-lang/martian/blob/master/src/martian/syntax/lexer.go).
+The Martian language's tokens are defined by regular expressions in its [lexical scanner](https://github.com/martian-lang/martian/blob/master/martian/syntax/lexer.go).
 
-The Martian syntax is specified as a [YACC grammar](https://github.com/martian-lang/martian/blob/master/src/martian/syntax/grammar.y).
+The Martian syntax is specified as a [YACC grammar](https://github.com/martian-lang/martian/blob/master/martian/syntax/grammar.y).
 
 ## Symbols and Scope
 
@@ -26,7 +26,7 @@ The following naming conventions are strongly recommended for consistency and re
 Stage and pipeline names should written in `ALL CAPS SNAKE_CASE`.
 
 - Stage names should be a subject and verb: `FIND_DIPS`, `CALL_VARIANTS`
-- Pipelines names should be "actor nouns": `COIN_SORTER`, `DYSON_SPHERE_DETECTOR`, `SVCALLER`
+- Pipelines names should be "actor nouns": `COIN_SORTER`, `DYSON_SPHERE_DETECTOR`, `SV_CALLER`
 - Names of pipelines intended to serve as subpipelines should be prefixed with an underscore: `_METRICS_REPORTER`
 
 Parameter names should be written in `all lowercase snake_case`.

--- a/content/writing-pipelines/index.md
+++ b/content/writing-pipelines/index.md
@@ -26,7 +26,7 @@ Here is a basic stage definition example:
 ~~~~
 filetype txt;
 
-stage SORT(
+stage SORT_ITEMS(
     in  txt  unsorted,
     in  bool case_sensitive,
     out txt  sorted,
@@ -95,7 +95,7 @@ pipeline DUPLICATE_FINDER(
         unsorted = self.unsorted,
     )
     call FIND_DUPLICATES(
-        sorted = SORT.sorted,
+        sorted = SORT_ITEMS.sorted,
     )
     return (
         duplicates = FIND_DUPLICATES.duplicates,
@@ -106,8 +106,8 @@ pipeline DUPLICATE_FINDER(
 The example above does the following:
 
 - Declares a user-defined filetype `txt`
-- Declares two stages `SORT` and `FIND_DUPLICATES`
-- Declares a pipeline `DUPLICATE_FINDER` that calls both stages. It accepts one input `unsorted` which must be a filename ending in `.txt`. The `unsorted` parameter is then passed to the input of `SORT`, whose output is then passed to `FIND_DUPLICATES`. The output `duplicates` of `FIND_DUPLICATES` is then returned as the output of the whole pipeline.
+- Declares two stages `SORT_ITEMS` and `FIND_DUPLICATES`
+- Declares a pipeline `DUPLICATE_FINDER` that calls both stages. It accepts one input `unsorted` which must be a filename ending in `.txt`. The `unsorted` parameter is then passed to the input of `SORT_ITEMS`, whose output is then passed to `FIND_DUPLICATES`. The output `duplicates` of `FIND_DUPLICATES` is then returned as the output of the whole pipeline.
 
 The Martian GitHub repository includes
 [syntax highlighting](https://github.com/martian-lang/martian/tree/master/tools/syntax)

--- a/content/writing-pipelines/index.md
+++ b/content/writing-pipelines/index.md
@@ -47,7 +47,7 @@ that implements the logic of the stage. The type of this parameter indicates
 the language of that code. For example, a stage could refer to a Python module,
 or a C, C++, Go, or Rust binary, just to name a few possibilities.
 
-Currently the there are 3 values supported for the type parameter:
+Currently there are 2 values supported for the type parameter:
 
 |`src` type|Stage type|
 |---|---|

--- a/content/writing-pipelines/index.md
+++ b/content/writing-pipelines/index.md
@@ -251,7 +251,7 @@ files, emitting line-numbered messages for any errors encountered. If given the
 The following verification steps are performed:
 
 - **Preprocessing**: All `@include` directives are recursively evaluated.  Any preprocessing errors, such as a file not found, will stop `mrc` and be reported.
-- **Lexing and Parsing**: The MRO code produced by the preprocessor is then lexed and parsed according to the [Martian grammar](https://github.com/martian-lang/martian/blob/master/src/martian/syntax/grammar.y) to produce an in-memory representation of the pipeline called an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) (AST).  Any syntax errors will stop `mrc` and be reported.
+- **Lexing and Parsing**: The MRO code produced by the preprocessor is then lexed and parsed according to the [Martian grammar](https://github.com/martian-lang/martian/blob/master/martian/syntax/grammar.y) to produce an in-memory representation of the pipeline called an [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) (AST).  Any syntax errors will stop `mrc` and be reported.
 - **Semantic Analysis**: The AST produced by the parser abstract syntax tree is then analyzed according a number of semantic rules. Any semantic errors will will be reported.
   - All referenced types are built-ins or user-defined with `filetype`.
   - All called stages and pipelines are defined.

--- a/content/writing-stages/index.md
+++ b/content/writing-stages/index.md
@@ -18,7 +18,7 @@ $ stage_executable [args] <type> <metadata_path> <files_path> <journal_prefix>
 ~~~~
 
 In most cases the interpretation of the arguments is handled by a
-[language-specific adapter](#Language Adapters).
+[language-specific adapter](#language-adapters).
 The `type` argument is one of `split`, `join`, or `main` (`main` is run for
 chunk phases, or for stages which do not
 [split](../advanced-features/#parallelization) ). The stage executable should
@@ -26,7 +26,7 @@ switch on that type and provide implementations for each.
 
 The details of the interface are generally handled by a language-specific
 "adapter."  Currently, there are adapters for Python and Go in the main
-repository, and an adapter for [Rust]() in also available.  Adapters for
+repository, and an adapter for [Rust](https://github.com/martian-lang/martian-rust) in also available.  Adapters for
 scripting languages are generally distributed with martian and should be
 expected to be tied to a specific martian version, while adapters for
 compiled languages obviously need to be compiled with the stage code.
@@ -34,7 +34,7 @@ For details on the interface between the job monitor process and the
 adapter code, see the
 [adapter documentation in the Martian repository](https://github.com/martian-lang/martian/blob/master/adapters/README.md).
 When writing stage code, refer to the documentation for the
-[language-specific adapter](#Language Adapters) for additional details,
+[language-specific adapter](#language-adapters) for additional details,
 as they are intended to provide abstraction layers wrapping the interface
 to the martian runtime, such as managing interaction with the journal
 directory and accessing inputs and outputs.
@@ -142,7 +142,7 @@ Stage executables that are compiled must implement the command-line interface de
 ### [Rust](https://github.com/martian-lang/martian-rust)
 [ Documentation WIP ]
 
-### [Go](https://github.com/martian-lang/martian/blob/master/src/martian/adapter/adapter.go)
+### [Go](https://github.com/martian-lang/martian/blob/master/martian/adapter/adapter.go)
 To implement a stage with Go, simply import
 `github.com/martian-lang/martian/martian/adapter` and call the `RunStage`
 method with your stage code logic as parameters from the main() method.
@@ -150,7 +150,7 @@ method with your stage code logic as parameters from the main() method.
 Given `split`, `chunk`, `join` methods are given a `core.Metadata` object
 which provides access to args, outs, and so on.  For an example of how this
 can be used, see the
-[go-based integration test stage](https://github.com/10XDev/martian-public/blob/master/test/split_test_go/stages/sum_squares/sum_squares.go)
+[go-based integration test stage](https://github.com/martian-lang/martian/blob/master/martian/test/sum_squares/sum_squares.go)
 as an example.
 
 Stage code can write to the stage `log` file with `util.Log` and related

--- a/content/writing-stages/index.md
+++ b/content/writing-stages/index.md
@@ -43,16 +43,18 @@ directory and accessing inputs and outputs.
 Input: The `args` file (containing the json dictionary of stage inputs)
 
 Output: A `stage_defs` file, containing a json object containing two keys.
+
 - `chunks`: a list of objects containing the input arguments to each stage,
 and optional keys `__threads` and `__mem_gb` to override the default resource
 reservation for each chunk.
-- `join` (optinoal): an object containing `__threads` and `__mem_gb` overrides
+- `join` (optional): an object containing `__threads` and `__mem_gb` overrides
 to be used for the join phase.
 
 More details in [Advanced Features: Parallelization](../advanced-features/#parallelization).
 
 ### Join Interface
 Inputs:
+
 - `args`: The stage input arguments
 - `chunk_defs`: The chunk definitions produced by the split phase.
 - `chunk_outs`: A json serialized list aggregating the outputs from each chunk.


### PR DESCRIPTION
I was learning Martian today, and while following the docs (which are very nicely laid out, concise, and clear) I found some errors, and I long the way I thought, "I might as well just fork the docs if they're available since I'm going through them".

Here's my small contribution:

Committed each change in case you want to `revert` some. Mostly link refs and few gramatical errors, but I did make some judgments on what I thought was intended to be served (such as the [Split Interface](http://martian-lang.org/writing-stages/#split-interface) options section). Serves just fine locally.