### PR TITLE
Removed extra backquote

### DIFF
--- a/content/language-details/index.md
+++ b/content/language-details/index.md
@@ -120,7 +120,7 @@ stage STAGE2(
     in  STAGE1 in1,
     out string out1,
 )
-````
+```
 This is convenient particularly for strictly sequentia parts of pipelines where
 all of the outputs of one stage become inputs to the next stage, but care
 should be taken to limit the use of this type of typing to stages whose


### PR DESCRIPTION
As indicated in #8, this removes the extra backquote causing problems in https://martian-lang.org/language-details/